### PR TITLE
feat(devcontainer): add devcontainer for vscode users

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,19 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.194.0/containers/ubuntu/.devcontainer/base.Dockerfile
+
+# [Choice] Ubuntu version: bionic, focal
+ARG VARIANT="focal"
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+     && apt-get -y install --no-install-recommends \
+     python3 \
+     python3-pip \
+     build-essential
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+RUN pip install -U https://github.com/platformio/platformio-core/archive/develop.zip
+RUN platformio update
+# To get the test platforms
+RUN pip install PyYaml

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.194.0/containers/ubuntu
+{
+	"name": "marlin",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick an Ubuntu version: focal, bionic
+		"args": { "VARIANT": "focal" }
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"platformio.platformio-ide",
+		"MarlinFirmware.auto-build"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+
+
+	"mounts": [
+		"source=${env:HOME}${env:USERPROFILE}/.ssh,target=/home/vscode/.ssh,type=bind,readonly",
+		"source=platformio-cache,target=/root/.platformio,type=volume"
+	]
+}


### PR DESCRIPTION
### Description

feat(devcontainer): add devcontainer for vscode users. 

### Requirements

vscode

### Benefits

Enables users to have a working environment out of the box. The endu ser doesn't have to install any additional tool/library.

### Test

Open vscode and select `reopen in devcontainer` 

![image](https://user-images.githubusercontent.com/18494471/196162384-5076952a-5c39-484f-827e-7ed1ade3ebab.png)


### Configurations

NIL

### Related Issues

NIL
